### PR TITLE
fix ensurefolder

### DIFF
--- a/jsonfile-store.js
+++ b/jsonfile-store.js
@@ -40,6 +40,7 @@ module.exports = function( options ) {
       if( exists ) return cb();
 
       fs.mkdir(folder,function(err){
+        if (err && err.code === 'EEXIST') err = null
         cb(err)
       })
     })

--- a/jsonfile-store.js
+++ b/jsonfile-store.js
@@ -35,15 +35,21 @@ module.exports = function( options ) {
   }
 
 
-  function ensurefolder(folder,cb){
-    fs.exists(folder,function(exists){
-      if( exists ) return cb();
-
-      fs.mkdir(folder,function(err){
-        if (err && err.code === 'EEXIST') err = null
-        cb(err)
-      })
-    })
+  /**
+   * Return if the folder exists, create otherwise.
+   */
+  function ensurefolder(folder, cb){
+    fs.stat(folder, function(err, stat) {
+      if (!err && stat.isDirectory()) {
+        return cb();
+      }
+      fs.mkdir(folder, function(err) {
+        if (err && err.code === 'EEXIST') {
+          err = null;
+        }
+        cb(err);
+      });
+    });
   }
 
 


### PR DESCRIPTION
**ensurefolder** tries to **fs.mkdir** and returns error if any occurs. The problem is when **fs.mkdir** returns error stating that the folder already exists. **ensurefolder** sends that out as an error, which causes a snowballing effect.

As ensurefolder's role is to make sure folder exists, it shouldn't really return an error saying a folder exists, right?